### PR TITLE
extended fallback if hasNavigationBar is false

### DIFF
--- a/Sources/UIViewController+NavigationBar.m
+++ b/Sources/UIViewController+NavigationBar.m
@@ -129,10 +129,14 @@ void UIViewControllerNavigationBarSwizzle(Class cls, SEL originalSelector) {
 #pragma mark - View life cycle
 
 - (void)UIViewControllerNavigationBar_viewWillAppear:(BOOL)animated {
-    [self UIViewControllerNavigationBar_viewWillAppear:animated];
-    [self.navigationController setNavigationBarHidden:self.hasNavigationBar animated:animated];
-    self.navigationController.interactivePopGestureRecognizer.delegate = nil;
-    [self updateNavigationItem];
+    if (self.hasNavigationBar) {
+        [self UIViewControllerNavigationBar_viewWillAppear:animated];
+        [self.navigationController setNavigationBarHidden:self.hasNavigationBar animated:animated];
+        self.navigationController.interactivePopGestureRecognizer.delegate = nil;
+        [self updateNavigationItem];
+    } else {
+        [self UIViewControllerNavigationBar_viewWillAppear:animated];
+    }
 }
 
 - (void)UIViewControllerNavigationBar_viewDidLayoutSubviews {


### PR DESCRIPTION
I've tweaked the viewWillAppear method to recognize `hasNavigationbar`.
If this is false, it will just call the super viewWillAppear method.
